### PR TITLE
Library requires "tests" folder to be autoloaded on any environment

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,8 +29,12 @@
       "RonasIT\\Support\\": "src/"
     },
     "files": [
-      "tests/TestCase.php",
       "src/helpers.php"
+    ]
+  },
+  "autoload-dev": {
+    "files": [
+      "tests/TestCase.php"
     ]
   },
   "minimum-stability": "stable",


### PR DESCRIPTION
This issue forces applications that use this library to autoload "tests" folder on all of their environments too.

This PR moves "tests" folder from "autoload" to "autoload-dev" block in composer.json