### PR TITLE
fix: unable to generate requests at Windows

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   ],
   "require": {
     "php": ">=7.4",
-    "laravel/framework": ">=5.4.0",
+    "laravel/framework": ">=5.5.0",
     "guzzlehttp/guzzle": ">=6.0",
     "maatwebsite/excel": "3.*",
     "tecnickcom/tcpdf": "~6.2.22",

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -106,7 +106,10 @@ function mkdir_recursively($path)
         $path = str_replace(DIRECTORY_SEPARATOR, '/', $path);
     }
 
-    $path = str_replace($currentPath, '', $path);
+    if (strpos($path, $currentPath) !== false) {
+        $path = substr_replace($path, '', strpos($currentPath, $path), strlen($currentPath));
+    }
+
     $explodedPath = explode('/', $path);
 
     array_walk($explodedPath, function ($dir) use (&$currentPath) {

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Support\Collection;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 
 /**
  * Round all values in list of floats.
@@ -106,14 +107,11 @@ function mkdir_recursively($path)
         $path = str_replace(DIRECTORY_SEPARATOR, '/', $path);
     }
 
-    if (strpos($path, $currentPath) !== false) {
-        $path = substr_replace($path, '', strpos($currentPath, $path), strlen($currentPath));
-    }
-
+    $path = Str::replaceFirst($currentPath, '', $path);
     $explodedPath = explode('/', $path);
 
     array_walk($explodedPath, function ($dir) use (&$currentPath) {
-        if ($currentPath != '/') {
+        if ($currentPath !== '/') {
             $currentPath .= '/' . $dir;
         } else {
             $currentPath .= $dir;

--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -297,4 +297,15 @@ class HelpersTest extends HelpersTestCase
 
         $this->assertEqualsFixture('array_remove_elements/result.json', $result);
     }
+
+    public function testMkDirRecursively()
+    {
+        mkdir_recursively('dir1/dir2/dir3');
+
+        $this->assertTrue(file_exists('dir1'));
+        $this->assertTrue(file_exists('dir1/dir2'));
+        $this->assertTrue(file_exists('dir1/dir2/dir3'));
+
+        rmdir_recursively('dir1');
+    }
 }


### PR DESCRIPTION
It was the issue when you have the path like `/app/app/something-else` and during the replacing of the base path like `/app` it removes more than it should. As result we have an incorrect path `/something-else` which can't be handled correctly.

Right now I checked on WIndows and on MacOS. Both works fine:

<img width="865" alt="image" src="https://github.com/RonasIT/laravel-helpers/assets/1735581/36d51fe6-e93d-4b61-9694-74cce3bea7db">

<img width="579" alt="image" src="https://github.com/RonasIT/laravel-helpers/assets/1735581/1d980062-a88b-4836-b818-f4c1ad3b56d6">
