### PR TITLE
test: cover laravel 9 mailable subject

### DIFF
--- a/src/Traits/MailsMockTrait.php
+++ b/src/Traits/MailsMockTrait.php
@@ -96,12 +96,22 @@ trait MailsMockTrait
         $expectedSubject = Arr::get($currentMail, 'subject');
 
         if (!empty($expectedSubject)) {
-            $this->assertEquals(
-                $expectedSubject,
-                $mail->subject,
-                "Failed assert that the expected subject \"{$expectedSubject}\" equals "
-                . "to the actual \"{$mail->subject}\"."
-            );
+            if (method_exists($mail, 'hasSubject')) {
+                $subject = method_exists($mail, 'envelope') ? $mail->envelope()->subject : $mail->subject;
+
+                $this->assertTrue(
+                    $mail->hasSubject($expectedSubject),
+                    "Failed assert that the expected subject \"{$expectedSubject}\" equals "
+                    . "to the actual \"{$subject}\"."
+                );
+            } else {
+                $this->assertEquals(
+                    $expectedSubject,
+                    $mail->subject,
+                    "Failed assert that the expected subject \"{$expectedSubject}\" equals "
+                    . "to the actual \"{$mail->subject}\"."
+                );
+            }
         }
     }
 

--- a/tests/MailsMockTraitTest.php
+++ b/tests/MailsMockTraitTest.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Mail;
 use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\ExpectationFailedException;
 use RonasIT\Support\Tests\Support\Mock\TestMail;
+use RonasIT\Support\Tests\Support\Mock\TestMailHasSubject;
 
 class MailsMockTraitTest extends HelpersTestCase
 {
@@ -35,13 +36,13 @@ class MailsMockTraitTest extends HelpersTestCase
 
     public function testMailWithAllParameters()
     {
-        Mail::to('test@mail.com')->queue(new TestMail(
+        Mail::to('test@mail.com')->queue(new TestMailHasSubject(
             ['name' => 'John Smith'],
             'emails.test',
             'Test Subject',
         ));
 
-        $this->assertMailEquals(TestMail::class, [
+        $this->assertMailEquals(TestMailHasSubject::class, [
             [
                 'emails' => 'test@mail.com',
                 'fixture' => 'test_mail.html',

--- a/tests/support/Mock/TestMailHasSubject.php
+++ b/tests/support/Mock/TestMailHasSubject.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace RonasIT\Support\Tests\Support\Mock;
+
+
+class TestMailHasSubject extends TestMail
+{
+    public function hasSubject(string $subject): bool
+    {
+        return ($this->subject === $subject);
+    }
+}

--- a/tests/support/Mock/TestMailHasSubject.php
+++ b/tests/support/Mock/TestMailHasSubject.php
@@ -2,7 +2,6 @@
 
 namespace RonasIT\Support\Tests\Support\Mock;
 
-
 class TestMailHasSubject extends TestMail
 {
     public function hasSubject(string $subject): bool


### PR DESCRIPTION
I checked out new MailsMockTrait on Empty Project and found that we are not testing Mailable's `subject` for Larval 9.