### PR TITLE
Exclude postgis tables from reset sequence

### DIFF
--- a/src/Traits/FixturesTrait.php
+++ b/src/Traits/FixturesTrait.php
@@ -163,7 +163,10 @@ trait FixturesTrait
         $except = array_merge($this->postgisTables, $this->prepareSequencesExceptTables, $except);
 
         $query = array_concat($this->getSequences(), function ($item) use ($except) {
-            if (in_array($item->table_name, $except)) {
+            if (
+                in_array($item->table_name, $except)
+                || in_array("{$item->table_schema}.{$item->table_name}", $except)
+            ) {
                 return '';
             } else {
                 $sequenceName = str_replace(["nextval('", "'::regclass)"], '', $item->column_default);
@@ -201,7 +204,7 @@ trait FixturesTrait
         if (empty(self::$sequences)) {
             self::$sequences = app('db.connection')
                 ->table('information_schema.columns')
-                ->select('table_name', 'column_name', 'column_default')
+                ->select('table_name', 'table_schema', 'column_name', 'column_default')
                 ->where('column_default', 'LIKE', 'nextval%')
                 ->get()
                 ->toArray();

--- a/tests/fixtures/FixturesTraitTest/prepare_sequences/information_schema.json
+++ b/tests/fixtures/FixturesTraitTest/prepare_sequences/information_schema.json
@@ -1,37 +1,56 @@
 [
   {
     "table_name": "articles",
+    "table_schema": "public",
     "column_name": "id",
     "column_default": "nextval('articles_id_seq'::regclass)"
   },
   {
     "table_name": "workers",
+    "table_schema": "public",
     "column_name": "id",
     "column_default": "nextval('workers_id_seq'::regclass)"
   },
   {
     "table_name": "groups",
+    "table_schema": "public",
     "column_name": "id",
     "column_default": "nextval('groups_id_seq'::regclass)"
   },
   {
     "table_name": "homes",
+    "table_schema": "public",
     "column_name": "id",
     "column_default": "nextval('homes_id_seq'::regclass)"
   },
   {
     "table_name": "users",
+    "table_schema": "public",
     "column_name": "id",
     "column_default": "nextval('users_id_seq'::regclass)"
   },
   {
     "table_name": "roles",
+    "table_schema": "public",
     "column_name": "id",
     "column_default": "nextval('roles_id_seq'::regclass)"
   },
   {
     "table_name": "telescope_entries",
+    "table_schema": "public",
     "column_name": "sequence",
     "column_default": "nextval('telescope_entries_sequence_seq'::regclass)"
+  },
+  {
+    "table_name": "state",
+    "table_schema": "tiger",
+    "column_name": "gid",
+    "column_default": "nextval('tiger.state_gid_seq'::regclass)"
+  },
+  {
+    "table_name": "topology",
+    "table_schema": "topology",
+    "column_name": "id",
+    "column_default": "nextval('topology.topology_id_seq'::regclass)"
   }
 ]


### PR DESCRIPTION
When we prepare the list of tables and keys for the resetting sequence, we don't exclude the PostGIS tables from that list.