### PR TITLE
Allow to test mail attachments

### DIFF
--- a/src/Traits/MailsMockTrait.php
+++ b/src/Traits/MailsMockTrait.php
@@ -75,6 +75,7 @@ trait MailsMockTrait
             $this->assertEmailsList($expectedMailData, $mail, $index);
             $this->assertFixture($expectedMailData, $mail, $exportMode);
             $this->assertEmailFrom($expectedMailData, $mail);
+            $this->assertAttachments($expectedMailData, $mail, $index);
 
             $index++;
 
@@ -200,13 +201,36 @@ trait MailsMockTrait
         return (is_multidimensional($emailChain)) ? $emailChain : [$emailChain];
     }
 
-    protected function mockedMail($emails, string $fixture, string $subject = '', $from = ''): array
+    protected function mockedMail($emails, string $fixture, string $subject = '', $from = '', $attachments = []): array
     {
         return [
             'emails' => $emails,
             'fixture' => $fixture,
             'subject' => $subject,
             'from' => $from,
+            'attachments' => $attachments,
         ];
+    }
+
+    protected function assertAttachments(array $currentMail, Mailable $mail, int $index): void
+    {
+        $expectedAttachments = Arr::get($currentMail, 'attachments');
+
+        if (!empty($expectedAttachments)) {
+            $expectedAttachmentsCount = count($expectedAttachments);
+
+            if (method_exists($mail, 'attachments')) {
+                $attachmentsCount = count($mail->attachments);
+
+                $this->assertCount(
+                    $expectedAttachmentsCount,
+                    $mail->attachments,
+                    "Mail contains {$attachmentsCount} attachments instead of {$expectedAttachmentsCount}"
+                    . " on the step: {$index}."
+                );
+            } else {
+                $this->fail("Mail contains 0 attachments instead of {$expectedAttachmentsCount} on the step: {$index}.");
+            }
+        }
     }
 }

--- a/tests/MailsMockTraitTest.php
+++ b/tests/MailsMockTraitTest.php
@@ -130,20 +130,29 @@ class MailsMockTraitTest extends HelpersTestCase
             ],
         ]);
     }
-
-    public function testMailWithUnwantedAttachments()
+    /*
+             * $this->assertMailEquals(BaseMail::class, [
+                [
+                    'subject' => 'Soenaw',
+                    'from' => 'sdfs',
+                    'attachments' => function ($mail) {
+                        return true;
+                    }
+                ]
+            ]);
+             */
+    public function testMailWithCallback()
     {
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Missing required key "fixture" in the input data set on the step: 0.');
-
         Mail::to('test@mail.com')->queue(new TestMailWithAttachments(
             ['name' => 'John Smith'],
             'subject',
             'emails.test'
         ));
 
-        $this->assertMailEquals(TestMail::class, [
-            $this->mockedMail('test@mail.com', 'test_mail.html', 'subject', []),
+        $this->assertMailEquals(TestMailWithAttachments::class, [
+            $this->mockedMail('test@mail.com', 'test_mail.html', 'subject', '', function ($mail) {
+                return !empty($mail->attachments());
+            }),
         ]);
     }
 }

--- a/tests/MailsMockTraitTest.php
+++ b/tests/MailsMockTraitTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\ExpectationFailedException;
 use RonasIT\Support\Tests\Support\Mock\TestMail;
 use RonasIT\Support\Tests\Support\Mock\TestMailHasSubject;
+use RonasIT\Support\Tests\Support\Mock\TestMailWithAttachments;
 
 class MailsMockTraitTest extends HelpersTestCase
 {
@@ -127,6 +128,22 @@ class MailsMockTraitTest extends HelpersTestCase
             [
                 'emails' => 'test@mail.com',
             ],
+        ]);
+    }
+
+    public function testMailWithUnwantedAttachments()
+    {
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Missing required key "fixture" in the input data set on the step: 0.');
+
+        Mail::to('test@mail.com')->queue(new TestMailWithAttachments(
+            ['name' => 'John Smith'],
+            'subject',
+            'emails.test'
+        ));
+
+        $this->assertMailEquals(TestMail::class, [
+            $this->mockedMail('test@mail.com', 'test_mail.html', 'subject', []),
         ]);
     }
 }

--- a/tests/support/Mock/TestMailWithAttachments.php
+++ b/tests/support/Mock/TestMailWithAttachments.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace RonasIT\Support\Tests\Support\Mock;
+
+use RonasIT\Support\Mail\BaseMail;
+
+class TestMailWithAttachments extends BaseMail
+{
+    public function __construct(array $viewData, $subject, $view)
+    {
+        parent::__construct($viewData, $subject, $view);
+
+        $this->setAddress('noreply@mail.net', null, 'from');
+    }
+
+    public function attachments(): array
+    {
+        return [
+            new \stdClass(),
+            new \stdClass(),
+        ];
+    }
+}


### PR DESCRIPTION
I implemented a callback function to test mail attachments and more.

Ref https://github.com/RonasIT/laravel-empty-project/issues/66