### PR TITLE
feat: clone user object pre send to actingAs

### DIFF
--- a/src/Traits/AuthTestTrait.php
+++ b/src/Traits/AuthTestTrait.php
@@ -3,6 +3,7 @@
 namespace RonasIT\Support\Traits;
 
 use Illuminate\Auth\SessionGuard;
+use Illuminate\Contracts\Auth\Authenticatable;
 
 trait AuthTestTrait
 {
@@ -13,5 +14,10 @@ trait AuthTestTrait
         return $this->withSession([
             "login_{$guard}_{$hash}" => $userId,
         ]);
+    }
+
+    public function actingAs(Authenticatable $user): self
+    {
+        return parent::actingAs(clone $user);
     }
 }

--- a/src/Traits/AuthTestTrait.php
+++ b/src/Traits/AuthTestTrait.php
@@ -16,8 +16,8 @@ trait AuthTestTrait
         ]);
     }
 
-    public function actingAs(Authenticatable $user): self
+    public function actingAs(Authenticatable $user, $guard = null): self
     {
-        return parent::actingAs(clone $user);
+        return parent::actingAs(clone $user, $guard);
     }
 }

--- a/tests/AuthTestTraitTest.php
+++ b/tests/AuthTestTraitTest.php
@@ -3,6 +3,8 @@
 namespace RonasIT\Support\Tests;
 
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Auth;
+use RonasIT\Support\Tests\Support\Mock\MockAuthUser;
 use RonasIT\Support\Traits\AuthTestTrait;
 use RonasIT\Support\Traits\FixturesTrait;
 
@@ -45,5 +47,20 @@ class AuthTestTraitTest extends HelpersTestCase
         $loginSession = $this->getLoginSession($session);
 
         $this->assertEmpty($loginSession);
+    }
+
+    public function testActingAs()
+    {
+        $mockedUser = new MockAuthUser();
+        $mockedUser->someIntProperty = 0;
+
+        $this->actingAs($mockedUser);
+
+        $user = Auth::user();
+        $user->someIntProperty = 1;
+
+        $this->actingAs($mockedUser);
+
+        $this->assertEquals(0, Auth::user()->someIntProperty);
     }
 }

--- a/tests/support/Mock/MockAuthUser.php
+++ b/tests/support/Mock/MockAuthUser.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace RonasIT\Support\Tests\Support\Mock;
+
+use Illuminate\Contracts\Auth\Authenticatable;
+
+class MockAuthUser implements Authenticatable
+{
+    public int $someIntProperty;
+
+    public function getAuthIdentifierName()
+    {
+        return 'some_auth_identifier_name';
+    }
+
+    public function getAuthIdentifier()
+    {
+        return 'some_auth_identifier';
+    }
+
+    public function getAuthPassword()
+    {
+        return 'some_auth_password';
+    }
+
+    public function getRememberToken()
+    {
+        return 'some_remember_token';
+    }
+
+    public function setRememberToken($value)
+    {
+    }
+
+    public function getRememberTokenName()
+    {
+        return 'some_remember_token_name';
+    }
+}


### PR DESCRIPTION
- added method actingAs to trait AuthTestTrait, this solution solve problem when test user define as static in tests. This protect for change user object on batch testing.