### PR TITLE
fix: error when the query string contains apostrophe

### DIFF
--- a/src/Traits/SearchTrait.php
+++ b/src/Traits/SearchTrait.php
@@ -282,7 +282,10 @@ trait SearchTrait
     {
         return function ($query) use ($field, $mask) {
             $databaseDriver = config('database.default');
-            $value = str_replace('{{ value }}', $this->filter['query'], $mask);
+            $value = ($databaseDriver === 'pgsql')
+                ? pg_escape_string($this->filter['query'])
+                : addslashes($this->filter['query']);
+            $value = str_replace('{{ value }}', $value, $mask);
             $operator = ($databaseDriver === 'pgsql')
                 ? 'ilike'
                 : 'like';

--- a/tests/SearchTraitTest.php
+++ b/tests/SearchTraitTest.php
@@ -188,7 +188,7 @@ class SearchTraitTest extends HelpersTestCase
 
         $this->testRepositoryClass
             ->searchQuery([
-                'query' => 'search_string'
+                'query' => 'search_\'string'
             ])
             ->filterByQuery(['query_field', 'another_query_field'])
             ->getSearchResults();
@@ -204,7 +204,7 @@ class SearchTraitTest extends HelpersTestCase
 
         $this->testRepositoryClass
             ->searchQuery([
-                'query' => 'search_string'
+                'query' => 'search_\'string'
             ])
             ->filterByQuery(['query_field', 'another_query_field'], "'%' || unaccent('{{ value }}') || '%'")
             ->getSearchResults();

--- a/tests/support/Traits/SqlMockTrait.php
+++ b/tests/support/Traits/SqlMockTrait.php
@@ -309,13 +309,13 @@ trait SqlMockTrait
     {
         $this->mockSelectWithAggregate(
             "select count(*) as aggregate from `test_models` "
-            . "where ((`query_field` like '%search_string%') or (`another_query_field` like '%search_string%')) "
-            . "and `test_models`.`deleted_at` is null"
+            . "where ((`query_field` like '%search_\'string%') or (`another_query_field` like '%search_\'string%')) "
+            . 'and `test_models`.`deleted_at` is null'
         );
 
         $this->mockSelect(
-            "select * from `test_models` where ((`query_field` like '%search_string%') "
-            . "or (`another_query_field` like '%search_string%')) and `test_models`.`deleted_at` is null "
+            "select * from `test_models` where ((`query_field` like '%search_\'string%') "
+            . "or (`another_query_field` like '%search_\'string%')) and `test_models`.`deleted_at` is null "
             . "order by `id` asc limit 15 offset 0",
             $selectResult
         );
@@ -325,15 +325,15 @@ trait SqlMockTrait
     {
         $this->mockSelectWithAggregate(
             'select count(*) as aggregate from "test_models" '
-            . 'where (("query_field"::text ilike \'%\' || unaccent(\'search_string\') || \'%\') '
-            . 'or ("another_query_field"::text ilike \'%\' || unaccent(\'search_string\') || \'%\')) '
+            . 'where (("query_field"::text ilike \'%\' || unaccent(\'search_\'\'string\') || \'%\') '
+            . 'or ("another_query_field"::text ilike \'%\' || unaccent(\'search_\'\'string\') || \'%\')) '
             . 'and "test_models"."deleted_at" is null'
         );
 
         $this->mockSelect(
             'select * from "test_models" '
-            . 'where (("query_field"::text ilike \'%\' || unaccent(\'search_string\') || \'%\') '
-            . 'or ("another_query_field"::text ilike \'%\' || unaccent(\'search_string\') || \'%\')) '
+            . 'where (("query_field"::text ilike \'%\' || unaccent(\'search_\'\'string\') || \'%\') '
+            . 'or ("another_query_field"::text ilike \'%\' || unaccent(\'search_\'\'string\') || \'%\')) '
             . 'and "test_models"."deleted_at" is null order by "id" asc limit 15 offset 0',
             $selectResult
         );


### PR DESCRIPTION
Ref #132 

I checked the fix on MySQL and PostgreSQL projects.

For MySQL here are the docs about the escaping https://dev.mysql.com/doc/refman/8.4/en/string-literals.html

And for the PostgreSQL  https://www.postgresql.org/docs/8.1/sql-syntax.html#:~:text=The%20standard%2Dcompliant%20way%20of,with%20a%20backslash%20(%5C').