### PR TITLE
chore: mark ClassAlreadyExistsException as deprecated

### DIFF
--- a/src/Exceptions/ClassAlreadyExistsException.php
+++ b/src/Exceptions/ClassAlreadyExistsException.php
@@ -2,6 +2,9 @@
 
 namespace RonasIT\Support\Exceptions;
 
+/**
+ * @deprecated Class was moved to the EntityGenerator package as it is used there.
+ */
 class ClassAlreadyExistsException extends EntityCreateException
 {
 }


### PR DESCRIPTION
Refs: https://github.com/RonasIT/laravel-helpers/issues/231