### PR TITLE
deps: change composer restriction to support guzzle v8

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,3 +9,10 @@ on:
 jobs:
   run-tests:
     uses: ronasit/github-actions/.github/workflows/tests.yml@main
+    with:
+      additional-package: guzzlehttp/guzzle
+      custom-exclude: |
+        [
+          {"laravel-version": "11.*", "additional-package-version": "8.*"},
+          {"laravel-version": "12.*", "additional-package-version": "8.*"}
+        ]

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   "require": {
     "ext-bcmath": "*",
     "ext-json": "*",
-    "guzzlehttp/guzzle": "^7.9.2",
+    "guzzlehttp/guzzle": "^7.9.2 || ^8.0",
     "laravel/framework": ">=11.0",
     "php": ">=8.3",
     "php-mock/php-mock-phpunit": "^2.10",

--- a/src/Services/HttpRequestService.php
+++ b/src/Services/HttpRequestService.php
@@ -119,7 +119,9 @@ class HttpRequestService
 
             return $this;
         } catch (RequestException $exception) {
-            $this->response = $exception->getResponse();
+            // TODO: drop guzzlehttp/guzzle ^7 support and replace with `$exception instanceof ResponseException`,
+            // getResponse() moved off the base RequestException in guzzle 8, ResponseException doesn't exist in guzzle 7.
+            $this->response = method_exists($exception, 'getResponse') ? $exception->getResponse() : null;
 
             throw $exception;
         } finally {
@@ -213,8 +215,12 @@ class HttpRequestService
             logger('-------------------------------------');
             logger('');
             logger('getting response: ');
-            logger('code', ["<{$this->response->getStatusCode()}>"]);
-            logger('body', ["<{$this->response->getBody()}>"]);
+
+            if (!empty($this->response)) {
+                logger('code', ["<{$this->response->getStatusCode()}>"]);
+                logger('body', ["<{$this->response->getBody()}>"]);
+            }
+
             logger('time', [$endTime]);
             logger('');
         }


### PR DESCRIPTION
## Summary
- Widen `guzzlehttp/guzzle` constraint to `^7.9.2 || ^8.0` so the package can run under Laravel 11/12 setups that resolve guzzle 8
- Fix `HttpRequestService` for guzzle 8's exception API changes: `RequestException::getResponse()`/`hasResponse()` moved to `ResponseException` and its subclasses, so a bare `RequestException` (no response received) previously crashed with `Error: Call to undefined method` instead of rethrowing the original failure; also guarded debug `logResponse()` against a null response for the same reason
- Add guzzle 8 to the CI matrix (excluded for laravel 11.*/12.* combinations)

## Note for consumers
- If your code catches `RequestException` directly and calls `getResponse()`/`hasResponse()`, check via `method_exists()` or `instanceof ResponseException` — those methods no longer exist on the base class in guzzle 8.
- `HttpRequestService::getResponse()` can legitimately return no response after a failed request without a server reply (DNS/connect/protocol errors) — don't assume a response is always present after catching an exception.

## Test plan
- [ ] `php artisan test --filter=HttpRequestServiceTest`
